### PR TITLE
feat: create default workspace if home workspace missing

### DIFF
--- a/db/workspaces.ts
+++ b/db/workspaces.ts
@@ -7,10 +7,28 @@ export const getHomeWorkspaceByUserId = async (userId: string) => {
     .select("*")
     .eq("user_id", userId)
     .eq("is_home", true)
-    .single()
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
 
   if (!homeWorkspace) {
-    throw new Error(error.message)
+    const { data: newWorkspace, error: createError } = await supabase
+      .from("workspaces")
+      .insert({
+        user_id: userId,
+        name: "Default Workspace",
+        is_home: true,
+      })
+      .select("*")
+      .single()
+
+    if (createError) {
+      throw new Error(createError.message)
+    }
+
+    return newWorkspace.id
   }
 
   return homeWorkspace.id


### PR DESCRIPTION
## Summary
- fallback to creating a default workspace if no home workspace exists

## Testing
- `npm test` *(fails: Playwright Test needs to be invoked via 'npx playwright test'; Test suite must contain at least one test)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894103041d88322afe4806516b008d1