### PR TITLE
feat: create default workspace if home workspace missing

### DIFF
--- a/db/workspaces.ts
+++ b/db/workspaces.ts
@@ -7,10 +7,39 @@ export const getHomeWorkspaceByUserId = async (userId: string) => {
     .select("*")
     .eq("user_id", userId)
     .eq("is_home", true)
-    .single()
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
 
   if (!homeWorkspace) {
-    throw new Error(error.message)
+    const defaultWorkspace: TablesInsert<"workspaces"> = {
+      user_id: userId,
+      name: "Default Workspace",
+      description: "My home workspace.",
+      default_context_length: 4096,
+      default_model: "gpt-4-turbo-preview",
+      default_prompt: "You are a friendly, helpful AI assistant.",
+      default_temperature: 0.5,
+      embeddings_provider: "openai",
+      include_profile_context: true,
+      include_workspace_instructions: true,
+      instructions: "",
+      is_home: true,
+    }
+
+    const { data: newWorkspace, error: createError } = await supabase
+      .from("workspaces")
+      .insert(defaultWorkspace)
+      .select("*")
+      .single()
+
+    if (createError) {
+      throw new Error(createError.message)
+    }
+
+    return newWorkspace.id
   }
 
   return homeWorkspace.id


### PR DESCRIPTION
## Summary
- fallback to creating a default workspace with required fields when no home workspace exists

## Testing
- `npm test` *(fails: Playwright Test needs to be invoked via 'npx playwright test'; Test suite must contain at least one test)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6894103041d88322afe4806516b008d1