### PR TITLE
feat: implement chat API route

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,45 +1,70 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest } from "next/server"
 import { cookies } from "next/headers"
 import { createServerClient } from "@supabase/ssr"
-import { Database } from "@/supabase/types"
 
 export async function POST(req: NextRequest) {
-  const cookieStore = cookies()
-  const supabase = createServerClient<Database>(
+  // Auth (server-side, cookie-based)
+  const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value
-        }
-      }
-    }
+    { cookies }
   )
+
   const {
     data: { user }
   } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json("Unauthorized", { status: 401 })
+  if (!user) return new Response("Unauthorized", { status: 401 })
 
-  const { chatId, message } = await req.json()
+  // Input
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    return new Response("Bad JSON", { status: 400 })
+  }
+  const { chatId, message } = body
+  if (!message || typeof message !== "string")
+    return new Response("Message required", { status: 400 })
 
-  let cid = chatId
+  // Create chat if first message, else ensure the chat belongs to the user
+  let cid: string | null = chatId ?? null
   if (!cid) {
     const { data, error } = await supabase
       .from("chats")
-      .insert({ user_id: user.id, title: message.slice(0, 40) } as any)
+      .insert({ user_id: user.id, title: message.slice(0, 60) })
       .select("id")
       .single()
-    if (error) return NextResponse.json(error.message, { status: 400 })
+    if (error) return new Response(error.message, { status: 400 })
     cid = data!.id
+  } else {
+    const { data, error } = await supabase
+      .from("chats")
+      .select("id")
+      .eq("id", cid)
+      .eq("user_id", user.id)
+      .single()
+    if (error || !data) return new Response("Forbidden", { status: 403 })
   }
 
-  await supabase
-    .from("messages")
-    .insert({ chat_id: cid, role: "user", content: message } as any)
+  // Persist user message
+  await supabase.from("messages").insert({
+    chat_id: cid,
+    role: "user",
+    content: message
+  })
+
+  // Stubbed assistant reply (replace with Llama later)
   const reply = `Echo: ${message}`
-  await supabase
-    .from("messages")
-    .insert({ chat_id: cid, role: "assistant", content: reply } as any)
-  return NextResponse.json({ chatId: cid, reply })
+  await supabase.from("messages").insert({
+    chat_id: cid,
+    role: "assistant",
+    content: reply
+  })
+
+  return Response.json({ chatId: cid, reply })
+}
+
+// Optional: health check
+export async function GET() {
+  return new Response("ok")
 }


### PR DESCRIPTION
## Summary
- replace chat API endpoint with Supabase-backed handler using cookie auth
- add stubbed assistant reply and health-check GET handler

## Testing
- `npm test` *(fails: openapi-conversion assertion, Playwright tests invoked under Jest)*

------
https://chatgpt.com/codex/tasks/task_b_68968114f2e48322a8ff2d8830892b36