### PR TITLE
Add Supabase auth confirm redirect

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,0 +1,16 @@
+import { createClient } from "@/lib/supabase/server"
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url)
+  const code = requestUrl.searchParams.get("code")
+
+  if (code) {
+    const cookieStore = cookies()
+    const supabase = createClient(cookieStore)
+    await supabase.auth.exchangeCodeForSession(code)
+  }
+
+  return NextResponse.redirect(requestUrl.origin)
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,7 +10,10 @@ export default function Page() {
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
     )
-    await supabase.auth.signInWithOtp({ email })
+    await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/auth/confirm` }
+    })
     alert("Magic link sent.")
   }
 


### PR DESCRIPTION
## Summary
- add `/auth/confirm` route to exchange Supabase magic link code for a session
- update login page OTP flow to redirect to confirm route

## Testing
- `npm test` *(fails: extractOpenapiData for body 2, Playwright tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68968bababa883228e2de691b36d247d